### PR TITLE
adding reader for stm32cubemx pin list output

### DIFF
--- a/kipart/__main__.py
+++ b/kipart/__main__.py
@@ -47,7 +47,7 @@ def main():
     parser.add_argument('-r', '--reader',
         nargs='?',
         type=str.lower,
-        choices=['generic', 'xilinxultra', 'xilinx7', 'xilinx6s', 'xilinx6v', 'psoc5lp'],
+        choices=['generic', 'xilinxultra', 'xilinx7', 'xilinx6s', 'xilinx6v', 'psoc5lp', 'stm32cube'],
         default='generic',
         help='Name of function for reading the CSV file.')
     parser.add_argument(

--- a/kipart/stm32cube_reader.py
+++ b/kipart/stm32cube_reader.py
@@ -1,0 +1,110 @@
+import csv
+from collections import defaultdict
+import re
+import pprint
+from operator import itemgetter
+import argparse
+import os
+import copy
+from collections import defaultdict
+from .common import *
+from .kipart import *
+
+pp = pprint.PrettyPrinter(indent=4)
+
+def parse_csv_file(csv_file):
+    """Parses the CSV file and returns a list of pins in the form of (number, 'name')"""
+
+    pins = []
+    reader = csv.reader(csv_file, delimiter=',', quotechar='"')
+    next(reader, None) # skip header
+    for row in reader:
+        number, name, ptype, signal, label = row
+
+        if label:
+            name += '/' + label
+        elif signal:
+            name += '/' + signal
+
+        name = name.replace(' ', '_')
+
+        print("%s: %s" % (number, name))
+        pins.append((number, name))
+
+    return pins
+
+def parse_portpin(name):
+    """Finds the port name and number of a pin in a string. If found
+    returns a tuple in the form of ('port_name', port_number).
+    Otherwise returns `None`.
+    """
+    m = re.search('P([A-Z])(\d+)', name)
+    if m:
+        port_name, port_number = m.groups()
+        return (port_name, int(port_number))
+
+def group_pins(pins):
+    """Groups pins together per their port name and functions. Returns a
+    dictionary of {'port': [pin]}."""
+    ports = defaultdict(list)
+
+    power_names = ['VDD', 'VSS', 'VCAP', 'VBAT', 'VREF']
+    config_names = ['OSC', 'NRST', 'SWCLK', 'SWDIO', 'BOOT']
+
+    for pin in pins:
+        number, name = pin
+        if any(pn in name for pn in power_names):
+            ports['power'].append(pin)
+
+        elif any(pn in name for pn in config_names):
+            ports['config'].append(pin)
+
+        else:
+            m = parse_portpin(name)
+            if m:
+                port_name, port_number = m
+                ports[port_name].append(pin)
+            else:
+                ports['other'].append(pin)
+
+    # sort pins
+    for port in ports:
+        # config and power gates are sorted according to their function name
+        if port in ['config', 'power']:
+            ports[port] = sorted(ports[port], key=itemgetter(1))
+        # IO ports are sorted according to port number
+        else:
+            ports[port] = sorted(ports[port], key=lambda p: parse_portpin(p[1])[1])
+
+    return ports
+
+def stm32cube_reader(csv_file):
+    print("Reading file %s..." % csv_file)
+    pins = parse_csv_file(csv_file)
+    print("File read. %d pins." % len(pins))
+
+    ports = group_pins(pins)
+    print("Pins are grouped as:")
+    pp.pprint(ports)
+
+    # create pin data
+    pin_data = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+
+    index = 0
+
+    for port_name in ports:
+        for p in ports[port_name]:
+            # Get the pin attributes from the cells of the row of data.
+            pin = copy.copy(DEFAULT_PIN) # Start off with default values for the pin.
+            pin.index = index = index + 1
+            pin.num = p[0]
+            pin.name = p[1]
+            pin.unit = port_name
+
+            pin_data[pin.unit][pin.side][pin.name].append(pin)
+
+    # use file name as the part name
+    part_name = os.path.splitext(os.path.split(csv_file.name)[1])[0]
+
+    # what should be the part_num?
+    yield part_name, pin_data


### PR DESCRIPTION
Hi @xesscorp,

I've previously created [this](https://hasanyavuz.ozderya.net/?p=274) script to create symbol libraries from csv files exported from STM32CubeMx tool. If you haven't heard, its an application to create projects for stm32 mcus. It also allows pin planning and afterwards you can export the pin layout as a csv file. My script used this csv file to create kicad symbols, similar to what kipart does.

The moment I saw kipart, I thought I should add my script to it. So here is a preliminary implementation. Its very crude at the moment. But if you agree to merge it I will clean it up, do some improvements and add documentation.

At the moment, this reader, will group each pin by their respective port. Power pins will be grouped as a unit and some configuration pins (boot, clock, programming etc) will be grouped as another unit. All pins are on the left (default side). It doesn't set the pin type but I can add this.