### PR TITLE
use natural sorting library for sorting unit names

### DIFF
--- a/kipart/kipart.py
+++ b/kipart/kipart.py
@@ -31,6 +31,7 @@ import math
 import re
 import importlib
 from affine import Affine
+from natsort import natsorted
 from .common import *
 
 __all__ = ['kipart']  # Only export this routine for use by the outside world.
@@ -373,7 +374,7 @@ def draw_symbol(lib_file, part_num, pin_data, sort_type, fuzzy_match):
     # Now create the units that make up the part. Unit numbers go from 1
     # up to the number of units in the part. The units are sorted by their
     # names before assigning unit numbers.
-    for unit_num, unit in enumerate([p[1] for p in sorted(pin_data.items())], 1):
+    for unit_num, unit in enumerate([p[1] for p in natsorted(pin_data.items())], 1):
 
         # The indices of the X and Y coordinates in a list of point coords.
         X = 0


### PR DESCRIPTION
I've noticed that when I used numbers as unit names, units are not correctly sorted because by default `sorted` function does string sorting.  This causes units to be sorted like this

1
10
11
...
2
20
21
...
3
30
...

I've used `natsorted` function which is provided by `natsort` library (available via pip) to solve this problem. `natsorted` is a function that just works, its even able to correctly sort text that has numbering in it such as "P0, P1, P2...".

I think [this](https://github.com/xesscorp/KiPart/blob/master/kipart/kipart.py#L475) line of code could also use `natsorted`, but I'm not exactly sure?