### PR TITLE
Added 'PDR' to config_names. It appears on some chips, specifically s…

### DIFF
--- a/kipart/stm32cube_reader.py
+++ b/kipart/stm32cube_reader.py
@@ -77,7 +77,7 @@ def group_pins(pins):
     ports = defaultdict(list)
 
     power_names = ['VDD', 'VSS', 'VCAP', 'VBAT', 'VREF']
-    config_names = ['OSC', 'NRST', 'SWCLK', 'SWDIO', 'BOOT']
+    config_names = ['OSC', 'NRST', 'PDR', 'SWCLK', 'SWDIO', 'BOOT']
 
     for pin in pins:
         number, name, ptype = pin


### PR DESCRIPTION
…tm32f405zgtx and must be put into ports['config']

Added 'PDR' to config_names. It appears on some chips, specifically stm32f405zgtx and must be put into ports['config']. Without that, group_pins(pins) cannot sort it into a meaningful category (line 96), putting it into a None category. That breaks the script when sorting (line 105).

```
kipart -r stm32cube --overwrite -o test.lib plain_stm32f405zgtx.csv 
Traceback (most recent call last):
  File "/usr/local/bin/kipart", line 9, in <module>
    load_entry_point('kipart==0.1.17', 'console_scripts', 'kipart')()
  File "/usr/local/lib/python3.4/dist-packages/kipart-0.1.17-py3.4.egg/kipart/__main__.py", line 127, in main
    append_to_lib = call_kipart(part_data_file)
  File "/usr/local/lib/python3.4/dist-packages/kipart-0.1.17-py3.4.egg/kipart/__main__.py", line 112, in call_kipart
    debug_level=args.debug)
  File "/usr/local/lib/python3.4/dist-packages/kipart-0.1.17-py3.4.egg/kipart/kipart.py", line 555, in kipart
    for part_num, pin_data in part_reader(part_data_file):
  File "/usr/local/lib/python3.4/dist-packages/kipart-0.1.17-py3.4.egg/kipart/stm32cube_reader.py", line 136, in stm32cube_reader
    ports = group_pins(pins)
  File "/usr/local/lib/python3.4/dist-packages/kipart-0.1.17-py3.4.egg/kipart/stm32cube_reader.py", line 105, in group_pins
    ports[port] = sorted(ports[port], key=lambda p: parse_portpin(p[1])[1])
  File "/usr/local/lib/python3.4/dist-packages/kipart-0.1.17-py3.4.egg/kipart/stm32cube_reader.py", line 105, in <lambda>
    ports[port] = sorted(ports[port], key=lambda p: parse_portpin(p[1])[1])
TypeError: 'NoneType' object is not subscriptable
```

This fixes it. PDR is a reset pin that appears on several chips, such as stm32f405zgt*.

The .csv I used for testing is attached:
[plain_stm32f405zgtx.csv.zip](https://github.com/xesscorp/KiPart/files/333711/plain_stm32f405zgtx.csv.zip)