### PR TITLE
new command line argument to set default side for pins

### DIFF
--- a/kipart/__main__.py
+++ b/kipart/__main__.py
@@ -60,12 +60,17 @@ def main():
         help=
         'Sort the part pins by their entry order in the CSV file, their pin number, or their pin name.')
     parser.add_argument(
+        '--reverse',
+        action = 'store_true',
+        help='Sort pins in reverse order.'
+    )
+    parser.add_argument(
         '--side',
         nargs='?',
         type=str.lower,
         choices=['left', 'right', 'top', 'bottom'],
         default='left',
-        help='which side to place the pins by default'
+        help='Which side to place the pins by default.'
     )
     parser.add_argument('-o', '--output',
         nargs='?',
@@ -116,6 +121,7 @@ def main():
                    lib_filename=args.output,
                    append_to_lib=append_to_lib,
                    sort_type=args.sort,
+                   reverse=args.reverse,
                    fuzzy_match=args.fuzzy_match,
                    bundle=args.bundle,
                    debug_level=args.debug)

--- a/kipart/__main__.py
+++ b/kipart/__main__.py
@@ -29,6 +29,7 @@ import io
 import zipfile
 from .__init__ import __version__
 from .kipart import *
+from .common import DEFAULT_PIN
 
 def main():
     parser = ap.ArgumentParser(
@@ -58,6 +59,14 @@ def main():
         default='row',
         help=
         'Sort the part pins by their entry order in the CSV file, their pin number, or their pin name.')
+    parser.add_argument(
+        '--side',
+        nargs='?',
+        type=str.lower,
+        choices=['left', 'right', 'top', 'bottom'],
+        default='left',
+        help='which side to place the pins by default'
+    )
     parser.add_argument('-o', '--output',
         nargs='?',
         type=str,
@@ -110,6 +119,8 @@ def main():
                    fuzzy_match=args.fuzzy_match,
                    bundle=args.bundle,
                    debug_level=args.debug)
+
+    DEFAULT_PIN.side = args.side
 
     append_to_lib = args.append
     for input_file in args.input_files:

--- a/kipart/kipart.py
+++ b/kipart/kipart.py
@@ -335,7 +335,7 @@ def row_key(pin):
     return pin[1][0].index
 
 
-def draw_symbol(lib_file, part_num, pin_data, sort_type, fuzzy_match):
+def draw_symbol(lib_file, part_num, pin_data, sort_type, reverse, fuzzy_match):
     '''Add a symbol for a part to the library.'''
 
     # Start the part definition with the header.
@@ -483,7 +483,7 @@ def draw_symbol(lib_file, part_num, pin_data, sort_type, fuzzy_match):
         # Draw the transformed pins for each side of the symbol.
         for side, side_pins in list(unit.items()):
             # Sort the pins names for the desired order: row-wise, numeric, alphabetical.
-            sorted_side_pins = sorted(list(side_pins.items()), key=pin_key_func)
+            sorted_side_pins = sorted(list(side_pins.items()), key=pin_key_func, reverse=reverse)
             # Draw the transformed pins for this side of the symbol.
             draw_pins(lib_file, unit_num, sorted_side_pins, transform[side],
                       fuzzy_match)
@@ -533,6 +533,7 @@ def do_bundling(pin_data, bundle, fuzzy_match):
 def kipart(reader_type, part_data_file, lib_filename,
            append_to_lib=False,
            sort_type='name',
+           reverse=False,
            fuzzy_match=False,
            bundle=False,
            debug_level=0):
@@ -566,6 +567,7 @@ def kipart(reader_type, part_data_file, lib_filename,
                         part_num=part_num,
                         pin_data=pin_data,
                         sort_type=sort_type,
+                        reverse=reverse,
                         fuzzy_match=fuzzy_match)
 
     # This enables library-appending if it was already on upon entry to the routine


### PR DESCRIPTION
This adds a new command line argument `--side` to set the default side for the pins.

Since `-s` is already short for `--sort` I couldn't think of an argument letter for this.

If you agree to merge, I will add documentation.