### PR TITLE
fix optional oscillator pins always put in config

### DIFF
--- a/kipart/stm32cube_reader.py
+++ b/kipart/stm32cube_reader.py
@@ -77,7 +77,7 @@ def group_pins(pins):
     ports = defaultdict(list)
 
     power_names = ['VDD', 'VSS', 'VCAP', 'VBAT', 'VREF']
-    config_names = ['OSC', 'NRST', 'SWCLK', 'SWDIO', 'BOOT']
+    config_names = ['RCC_OSC', 'NRST', 'SWCLK', 'SWDIO', 'BOOT']
 
     for pin in pins:
         number, name, ptype = pin


### PR DESCRIPTION
Oscillator pins are always put into the 'config' group even if they are not selected as oscillator pins in stm32cube. This is the fix.