### PR TITLE
Update xilinx7_reader.py

### DIFF
--- a/kipart/xilinx7_reader.py
+++ b/kipart/xilinx7_reader.py
@@ -144,4 +144,4 @@ def xilinx7_reader(csv_file):
         # We'll unbundle them later, if necessary.
         pin_data[pin.unit][pin.side][pin.name].append(pin)
 
-    yield part_num, pin_data  # Return the dictionary of pins extracted from the CVS file.
+    yield part_num,'U', pin_data  # Return the dictionary of pins extracted from the CVS file.


### PR DESCRIPTION
There are three parametres expected: partnum, Part prefix and pindata. Part prefix is now fixed to U