### PR TITLE
adding tool to convert machxo3 lattice csv pinout into kipart readable

### DIFF
--- a/tools/machxo3tokipart.py
+++ b/tools/machxo3tokipart.py
@@ -55,7 +55,6 @@ class MachXO3toKipart(object):
                         self._packages_dict[package.strip()]=i
                         i+=1
                     break
-            print(self._packages_dict)
             # Parse header with package list
             if listpackage:
                 return
@@ -91,11 +90,9 @@ class MachXO3toKipart(object):
                 foutput.write("{}\n".format(self._partname))
             foutput.write("\n")
             foutput.write("Pin, Unit, Name\n")
-            print(self._pinoutdict[10])
             for rawpin in self._pinoutdict.keys():
                 pin = self._pinoutdict[rawpin]
                 pindex = self._packages_dict[self._package]
-                print(pin)
                 if pin[pindex]!= '-':
                     foutput.write("{}, BANK{}, {}{}{}\n"
                                  .format(pin[pindex],

--- a/tools/machxo3tokipart.py
+++ b/tools/machxo3tokipart.py
@@ -1,0 +1,148 @@
+#! /usr/bin/python3
+# -*- coding: utf-8 -*-
+#-----------------------------------------------------------------------------
+# Author:   Fabien Marteau <fabien.marteau@armadeus.com>
+# Created:  24/06/2019
+#-----------------------------------------------------------------------------
+#  Copyright (2019)  Armadeus Systems
+#-----------------------------------------------------------------------------
+""" machxo3tokipart
+"""
+
+import sys
+import getopt
+
+def usages():
+    print("Usage:")
+    print("python3 machxo3tokipart.py [options]")
+    print("-h, help                 This usage message")
+    print("-c, csv=FILENAME         give the filename of lattice csv")
+    print("-p, package=CABGA256     Package to use")
+    print("-l, list                 list packages available")
+    print("-n, partname=name        part name (filename in not present)")
+
+
+class MachXO3toKipartError(Exception):
+    pass
+
+
+class MachXO3toKipart(object):
+    """
+    """
+
+    def __init__(self, package=None, csvname=None,
+            listpackage=False, partname=None):
+        self._partname = partname
+        self._package = package
+        self._csvname = csvname
+        self._listpackage = listpackage
+        self._packages_available = []
+        self._header = None
+
+    def parse(self):
+
+        with open(self._csvname, "r") as fcsv:
+            for line in fcsv:
+                if line[0] == '#' or line[0] == ",":
+                    print(line)
+                else:
+                    self._header = line.split(',')
+                    self._packages_available = self._header[8:]
+                    self._packages_dict = {}
+                    i = 8 
+                    for package in self._packages_available:
+                        self._packages_dict[package.strip()]=i
+                        i+=1
+                    break
+            print(self._packages_dict)
+            # Parse header with package list
+            if listpackage:
+                return
+            if self._package not in self._packages_available:
+                raise MachXO3toKipartError("No package named {} in {}"
+                                          .format(self._package,
+                                              self._packages_available))
+            # Parse pinout
+            self._pinoutdict = {}
+            power_index = 10000
+            for line in fcsv:
+                sline = line.split(',')
+                index = int(sline[0])
+                if index != 0:
+                    self._pinoutdict[index]=sline
+                else:
+                    self._pinoutdict[power_index]=sline
+                    power_index += 1
+
+
+    def listpackage_output(self):
+        print("Packages available are :")
+        for package in self._packages_available:
+            print(package)
+
+    def output(self, filename=None):
+        if filename is None:
+            raise MachXO3toKipartError("can't write output on stdout")
+        with open(filename, "w") as foutput:
+            if self._partname is None:
+                foutput.write(self._csvname.split(".")[0]+"\n")
+            else:
+                foutput.write("{}\n".format(self._partname))
+            foutput.write("\n")
+            foutput.write("Pin, Unit, Name\n")
+            print(self._pinoutdict[10])
+            for rawpin in self._pinoutdict.keys():
+                pin = self._pinoutdict[rawpin]
+                pindex = self._packages_dict[self._package]
+                print(pin)
+                if pin[pindex]!= '-':
+                    foutput.write("{}, BANK{}, {}{}{}\n"
+                                 .format(pin[pindex],
+                                     pin[2],
+                                     pin[1] if pin[1] != '-' else '',
+                                     "_" + pin[2] if pin[2] != '-' else '',
+                                     "_" + pin[3] if pin[3] != '-' else ''))
+
+
+if __name__ == "__main__":
+    print("Convert a lattice csv pinout for Kipart\n")
+    if sys.version_info[0] < 3:
+        raise Exception("Must be using Python 3")
+    print(MachXO3toKipart.__doc__)
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "hp:lc:o:p:n:",
+                                   ["help","package=", "partname="
+                                       "list", "csv=", "outputname="])
+    except getopt.GetoptError as err:
+        print(err)
+        usages()
+        sys.exit(2)
+
+    package = None
+    csvname = None
+    listpackage = False
+    outputname = None
+    partname = None
+    for opt, arg in opts:
+        if opt in ("-h", "--help"):
+            usages()
+            sys.exit()
+        elif opt in ("-p", "--package"):
+            package = arg
+        elif opt in ("-c", "--csv"):
+            csvname = arg
+        elif opt in ("-l", "--list"):
+            listpackage = True
+        elif opt in ("-o", "--outputname"):
+            outputname = arg
+        elif opt in ("-n", "--partname"):
+            partname = arg
+    
+    l2k = MachXO3toKipart(package, csvname, listpackage, partname)
+
+    l2k.parse()
+    if listpackage:
+        l2k.listpackage_output()
+    else:
+        l2k.output(outputname)
+

--- a/tools/machxo3tokipart.py
+++ b/tools/machxo3tokipart.py
@@ -17,6 +17,7 @@ def usages():
     print("python3 machxo3tokipart.py [options]")
     print("-h, help                 This usage message")
     print("-c, csv=FILENAME         give the filename of lattice csv")
+    print("-o, outputname=FILENAME  Output filename to write")
     print("-p, package=CABGA256     Package to use")
     print("-l, list                 list packages available")
     print("-n, partname=name        part name (filename in not present)")
@@ -108,7 +109,6 @@ if __name__ == "__main__":
     print("Convert a lattice csv pinout for Kipart\n")
     if sys.version_info[0] < 3:
         raise Exception("Must be using Python 3")
-    print(MachXO3toKipart.__doc__)
     try:
         opts, args = getopt.getopt(sys.argv[1:], "hp:lc:o:p:n:",
                                    ["help","package=", "partname="


### PR DESCRIPTION
I wrote a little python3 script to convert csv pinout machxo3 files found on [Lattice website](https://www.latticesemi.com/Products/FPGAandCPLD/MachXO3.aspx#_ECDB05A11084426E8559FE8E09809E8F) into csv readable with kipart.

```bash
$ python3 machxo3tokipart.py -h
Convert a lattice csv pinout for Kipart

Usage:
python3 machxo3tokipart.py [options]
-h, help                 This usage message
-c, csv=FILENAME         give the filename of lattice csv
-o, outputname=FILENAME  Output filename to write
-p, package=CABGA256     Package to use
-l, list                 list packages available
-n, partname=name        part name (filename in not present)
```

I'm using this script with machxo36900.csv pinout [from here](https://www.latticesemi.com/view_document?document_id=50412). The csv from lattice has this format : 

```
$ head MachXO36900Pinout.csv 
# Revision 1.0,13-Feb-14,Initial release,,,,,,,,,,
# Revision 1.1,14-May-14,"Added csfBGA256, csfBGA324, caBGA324, caBGA400 packages",,,,,,,,,,
# Revision 1.2,12-Sep-14,New csfBGA pinouts,,,,,,,,,,
,,,,,,,,,,,,
PAD,Pin/Ball Function,Bank,Dual Function,Differential,High Speed,,I/O Grouping,CABGA256,CABGA400,CABGA324,CSFBGA324,CSFBGA256
1,NC,-,-,-,-,,+,-,-,-,-,-
2,PL2A,5,-,True_OF_PL2B,-,,+,-,C4,B1,G12,-
3,GND,-,-,-,-,,-,-,-,-,-,-
4,PL2B,5,-,Comp_OF_PL2A,-,,-,-,C3,C2,C17,-
5,PL2C,5,-,True_OF_PL2D,-,,-,B1,F6,D3,C16,D13
```

We have to select bga to use with this command options : 

`$ python3 machxo3tokipart.py -c MachXO36900Pinout.csv -pCABGA256 -nMachXO36900_CABGA256 -o LatticeMachXO3.csv`

And the csv result has the following format : 

```
$ head LatticeMachXO3.csv 
MachXO36900_CABGA256

Pin, Unit, Name
B1, BANK5, PL2C_5
C2, BANK5, PL2D_5
D3, BANK5, PL3A_5_L_GPLLT_FB
D1, BANK5, PL3B_5_L_GPLLC_FB
E2, BANK5, PL4A_5_L_GPLLT_IN
E3, BANK5, PL4B_5_L_GPLLC_IN
C1, BANK5, PL4C_5
```

Then it can be converted in kicad symbol with kipart.


