### PR TITLE
Added a flag to set box fill

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -11,7 +11,7 @@ KiPart is mainly intended to be used as a script::
                 [-r [{generic,xilinxultra,xilinx7,xilinx6s,xilinx6v,psoc5lp,stm32cube,lattice,gowin}]]
                 [-s [{row,num,name}]] [--reverse]
                 [--side [{left,right,top,bottom}]] [-o [file.lib]] [-f] [-b]
-                [-a] [-w] [-d [LEVEL]]
+                [-a] [-w] [-d [LEVEL]] [--fill [{no_fill,fg_fill,bg_fill}]]
                 file.[csv|txt|xlsx|zip] [file.[csv|txt|xlsx|zip] ...]
 
     Generate single & multi-unit schematic symbols for KiCad from a CSV file.
@@ -43,6 +43,8 @@ KiPart is mainly intended to be used as a script::
     -w, --overwrite       Allow overwriting of an existing part library.
     -d [LEVEL], --debug [LEVEL]
                             Print debugging info. (Larger LEVEL means more info.)
+    --fill [{no_fill,fg_fill,bg_fill}]
+                            Whether to fill schematic boxes
 
 A generic part file is expected when the ``-r generic`` option is specified.
 It contains the following items:
@@ -152,6 +154,11 @@ If a part with the same name already exists, the new part will only overwrite it
 if the ``-w`` flag is also used.
 Any existing parts in the library that are not overwritten are retained.
 
+Specifying the ``--fill`` option will determine how schematic boxes are filled
+
+* ``no_fill``: Default. Schematic symbols are created with no filled boxes.
+* ``fg_fill``: Schematic boxes will be foreground filled
+* ``bg_fill``: Schematic boxes will be background filled
 
 Examples
 ^^^^^^^^^^^^

--- a/kipart/kipart.py
+++ b/kipart/kipart.py
@@ -72,7 +72,6 @@ PIN_SPACER_PREFIX = "*"
 
 # Settings for box drawn around pins in a unit.
 BOX_LINE_WIDTH = 12
-FILL = "no_fill"
 
 # Part reference.
 REF_SIZE = 60  # Font size.
@@ -499,6 +498,7 @@ def draw_symbol(
     sort_type,
     reverse,
     fuzzy_match,
+    fill,
 ):
     """Add a symbol for a part to the library."""
 
@@ -740,7 +740,7 @@ def draw_symbol(
             y1=int(box_pt["bottom"][Y]),
             unit_num=unit_num,
             line_width=BOX_LINE_WIDTH,
-            fill=FILLS[FILL],
+            fill=FILLS[fill],
         )
 
     # Close the section that holds the part's units.
@@ -781,6 +781,7 @@ def kipart(
     part_data_file_name,
     part_data_file_type,
     parts_lib,
+    fill,
     allow_overwrite=False,
     sort_type="name",
     reverse=False,
@@ -828,6 +829,7 @@ def kipart(
             sort_type=sort_type,
             reverse=reverse,
             fuzzy_match=fuzzy_match,
+            fill=fill,
         )
 
 
@@ -930,6 +932,14 @@ def main():
         metavar="LEVEL",
         help="Print debugging info. (Larger LEVEL means more info.)",
     )
+    parser.add_argument(
+        "--fill",
+        nargs="?",
+        type=lambda s: unicode(s).lower(),
+        choices=["no_fill", "fg_fill", "bg_fill"],
+        default="no_fill",
+        help="Whether to fill schematic boxes",
+    )
 
     args = parser.parse_args()
 
@@ -973,6 +983,7 @@ def main():
             part_data_file_name=file_name,
             part_data_file_type=file_type,
             parts_lib=parts_lib,
+            fill=args.fill,
             allow_overwrite=args.overwrite,
             sort_type=args.sort,
             reverse=args.reverse,


### PR DESCRIPTION
I wanted to be able to set the fill style from the cli, so I added an option, `--fill`, to accomplish this. Instead of a fixed global, the argument parser now passes the fill option into `draw_symbol` which generates the symbol boxes using the specified fill style.

I opted to use the existing naming convention as opposed to a more complex eg `--fill fg` or `--fill foreground` to map to `fg_fill` etc. I figure the names are still suitably self-explanatory and easy enough to type out.

The usage documentation has been updated to include the new optional flag, as well as an explanation of the available configurations in human-readable format. I did not include anything in the readme since this is a relatively trivial feature.