### PR TITLE
open readme in utf8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-with open("README.rst") as readme_file:
+with open("README.rst", "r", encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
 with open("HISTORY.rst") as history_file:


### PR DESCRIPTION
Avoid a `python setup.py build` error when using KiPart in Windows 10 CN (GBK encodings)

```
Traceback (most recent call last):
  File "setup.py", line 23, in <module>
    readme = readme_file.read()
UnicodeDecodeError: 'gbk' codec can't decode byte 0x94 in position 1190: illegal multibyte sequence
```