### PR TITLE
Assign the name in Unit column to Unit Display Name

### DIFF
--- a/kipart/kipart.py
+++ b/kipart/kipart.py
@@ -612,8 +612,13 @@ def symbol_to_csv_rows(symbol):
     rows.append(["pin", "name", "type", "side", "unit", "style", "hidden"])
 
     # Process units and pins
-    for unit_id, unit in enumerate(units, 1):
-        unit_id = symbol_name + "_" + str(unit_id)
+    for unit_index, unit in enumerate(units, 1):
+        # Check if the unit has a custom unit_name, otherwise use unit number
+        unit_name_search = unit.search("/symbol/unit_name", ignore_case=True)
+        if unit_name_search:
+            unit_id = unit_name_search[0][1]
+        else:
+            unit_id = str(unit_index)
         pins = unit.search("/symbol/pin", ignore_case=True)
         for pin in pins:
             number = pin.search("/pin/number", ignore_case=True)[0][1]
@@ -1110,6 +1115,11 @@ def rows_to_symbol(
 
         # Begin instantiating the Sexp for this unit of the symbol.
         unit_sexp = Sexp(["symbol", total_unit_name])
+        
+        # If the unit has a custom name defined in the CSV and it's a multi-unit symbol,
+        # add the unit_name to the KiCad symbol definition
+        if len(units) > 1 and unit_id != DEFAULT_UNIT_ID:
+            unit_sexp.append(["unit_name", unit_id])
 
         # Calculate dimensions for each side of the symbol unit based on pin counts and text sizes.
         # At this point, we assume each side is oriented vertically with horizontal pins

--- a/tests/unit/test_kipart.py
+++ b/tests/unit/test_kipart.py
@@ -112,8 +112,8 @@ def test_symbol_to_csv_rows():
         ["Reference:", "U"],
         ["Value:", "my_part"],
         ["pin", "name", "type", "side", "unit", "style", "hidden"],
-        ["1", "P1", "input", "left", "my_part_1", "line", "no"],
-        ["2", "P2", "output", "right", "my_part_1", "line", "yes"],
+        ["1", "P1", "input", "left", "1", "line", "no"],
+        ["2", "P2", "output", "right", "1", "line", "yes"],
     ]
     rows = symbol_to_csv_rows(Sexp(sexp))
     assert rows == expected_rows
@@ -314,13 +314,13 @@ def test_library_to_csv(tmp_path):
         ["Reference:", "U"],
         ["Value:", "my_part"],
         ["pin", "name", "type", "side", "unit", "style", "hidden"],
-        ["1", "P1", "input", "left", "my_part_1", "line", "no"],
+        ["1", "P1", "input", "left", "1", "line", "no"],
         [],
         ["part2", ""],
         ["Reference:", "U"],
         ["Value:", "part2"],
         ["pin", "name", "type", "side", "unit", "style", "hidden"],
-        ["1", "OUT", "output", "left", "part2_1", "line", "no"],
+        ["1", "OUT", "output", "left", "1", "line", "no"],
     ]
     with open(output_path) as f:
         reader = csv.reader(f)


### PR DESCRIPTION
Improves multi-unit symbol handling by properly assigning custom unit names from CSV data to KiCad symbol unit display names, enabling better organization of complex components with named functional units.

##  Changes

- Enhanced unit name handling: Modified symbol_to_csv_rows() to extract custom unit names from KiCad symbols instead of generating generic numbered names
- Added unit_name support: Updated rows_to_symbol() to write custom unit names to KiCad symbol definitions for multi-unit components
- Improved CSV output: Unit column now shows actual unit names (like "1") rather than prefixed identifiers (like "my_part_1")
- Updated test expectations: Modified unit tests to reflect the cleaner unit name output format
